### PR TITLE
Fix __str__ for polynomials containing powers starting in 1, degree for Polynomials with leading 0 terms.

### DIFF
--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -169,7 +169,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
                 sign = "+ "
 
             if is_leading[0]:
-                sign = "-" if sign == "- " else sign
+                sign = "-" if sign == "- " else ""
                 is_leading[0] = False
 
             # if ak is 1, the 1 is implicit when raising x to non-zero k,

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -93,7 +93,8 @@ class Polynomial:
         """Get the terms of self as a list of tuples in coeff, deg form.
         
         Terms are returned from largest degree to smallest degree, excluding
-        any terms with a zero coefficient."""
+        any terms with a zero coefficient.
+        """
         s_d = self.degree
         return [(coeff, s_d - deg) for deg, coeff
                 in enumerate(self) if coeff != 0]

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -176,7 +176,6 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         if self.degree < 0:
             return "0"
 
-        # Hacky method to check if a component is the leading term.
         def components(ak, k, is_leading):
             ak = str(ak)
 

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -78,7 +78,7 @@ class Polynomial:
         ind = 0
         while self._vector[ind] == 0:
             ind += 1
-        
+
         self._vector = self._vector[ind:]
         return len(self._vector) - 1
 
@@ -232,7 +232,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         self != 0 <==> self != Polynomial()
         """
         if other == 0:
-            return self.terms != []
+            return self._vector != []
 
         return self.terms != other.terms
 

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -90,7 +90,10 @@ class Polynomial:
 
     @property
     def terms(self):
-        """Get the terms of self as a list of tuples in coeff, deg form."""
+        """Get the terms of self as a list of tuples in coeff, deg form.
+        
+        Terms are returned from largest degree to smallest degree, excluding
+        any terms with a zero coefficient."""
         s_d = self.degree
         return [(coeff, s_d - deg) for deg, coeff
                 in enumerate(self) if coeff != 0]
@@ -205,8 +208,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         s_d = self.degree
         terms = ["{0}{1}{2}{3}".
                  format(*components(ak, k, k == s_d))
-                 for ak, k in self.terms
-                 if ak != 0]
+                 for ak, k in self.terms]
 
         return " ".join(terms)
 

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -75,12 +75,13 @@ class Polynomial:
         if not self:
             return -inf  # the degree of the zero polynomial is -infinity
 
+        # Trim vector down in case the leading degrees no longer exist.
         ind = 0
-        while self._vector[ind] == 0:
+        while self._vector[-ind-1] == 0:
             ind += 1
 
-        self._vector = self._vector[ind:]
-        return len(self._vector) - 1
+        self._vector = self._vector[:len(self._vector) - ind]
+        return len(self._vector) - 1 if self._vector else -inf
 
     @property
     def derivative(self):

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -176,21 +176,15 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
             return "0"
 
         # Hacky method to check if a component is the leading term.
-        is_leading = [True]
-
-        def components(ak, k):
+        def components(ak, k, is_leading):
             ak = str(ak)
 
             if ak[0] == "-":
                 # Strip - from ak
                 ak = ak[1:]
-                sign = "- "
+                sign = "- " if is_leading else "-"
             else:
-                sign = "+ "
-
-            if is_leading[0]:
-                sign = "-" if sign == "- " else ""
-                is_leading[0] = False
+                sign = "+ " if is_leading else ""
 
             # if ak is 1, the 1 is implicit when raising x to non-zero k,
             # so strip it.

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -155,27 +155,44 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         if self.degree < 0:
             return "0"
 
-        def ones_removed(ak, k):
-            #  the  coefficients before the non-zero-degree terms
-            #  should not be explicitly displayed if they are
-            #  1 or -1
-            if ak == 1 and k != 0:
-                return ""
-            if ak == -1 and k != 0:
-                return "-"
-            return ak
+        # Hacky method to check if a component is the leading term.
+        is_leading = [True]
 
-        terms = ["{0}x^{1}".
-                 format(ones_removed(ak, k), k)
-                 for k, ak in enumerate(self._vector)
+        def components(ak, k):
+            ak = str(ak)
+
+            if is_leading[0]:
+                sign = ""
+                is_leading[0] = False
+            else:
+                if ak[0] == "-":
+                    # Strip - from ak
+                    ak = ak[1:]
+                    sign = "- "
+                else:
+                    sign = "+ "
+
+            # if ak is 1, the 1 is implicit, so strip it.
+            ak = "" if ak == "1" else ak
+
+            # set x^k portion.
+            if k == 0:
+                p, k = "", ""
+            elif k == 1:
+                p, k = "x", ""
+            else:
+                p = "x^"
+
+            return sign, ak, p, k
+
+        # 0: sign, 1: coeff, 2: x^, 3: a
+        # eg. -         5       x^     2
+        terms = ["{0}{1}{2}{3}".
+                 format(*components(ak, self.degree - k))
+                 for k, ak in enumerate(self)
                  if ak != 0]
-        joined_terms = " + ".join(reversed(terms)) + " "
-        replace_terms = {"x^1 ": "x",
-                         "x^0": "",
-                         " + -": " - "}
-        for k, v in replace_terms.items():
-            joined_terms = joined_terms.replace(k, v)
-        return joined_terms[:-1]
+
+        return " ".join(terms)
 
     def __eq__(self, other):
         """Return self == other.

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -161,19 +161,20 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         def components(ak, k):
             ak = str(ak)
 
-            if is_leading[0]:
-                sign = ""
-                is_leading[0] = False
+            if ak[0] == "-":
+                # Strip - from ak
+                ak = ak[1:]
+                sign = "- "
             else:
-                if ak[0] == "-":
-                    # Strip - from ak
-                    ak = ak[1:]
-                    sign = "- "
-                else:
-                    sign = "+ "
+                sign = "+ "
 
-            # if ak is 1, the 1 is implicit, so strip it.
-            ak = "" if ak == "1" else ak
+            if is_leading[0]:
+                sign = "-" if sign == "- " else sign
+                is_leading[0] = False
+
+            # if ak is 1, the 1 is implicit when raising x to non-zero k,
+            # so strip it.
+            ak = "" if ak == "1" and k != 0 else ak
 
             # set x^k portion.
             if k == 0:

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -89,12 +89,14 @@ class Polynomial:
 
     @property
     def terms(self):
+        """Get the terms of self as a list of tuples in coeff, deg form."""
         s_d = self.degree
         return [(coeff, s_d - deg) for deg, coeff
                 in enumerate(self) if coeff != 0]
 
     @terms.setter
     def terms(self, terms):
+        """Set the terms of self as a list of tuples in coeff, deg form."""
         max_deg = max(terms, key=lambda x: x[1])[1] + 1
         self._vector = [0] * max_deg
         for coeff, deg in terms:

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -182,9 +182,9 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
             if ak[0] == "-":
                 # Strip - from ak
                 ak = ak[1:]
-                sign = "- " if is_leading else "-"
+                sign = "-" if is_leading else "- "
             else:
-                sign = "+ " if is_leading else ""
+                sign = "" if is_leading else "+ "
 
             # if ak is 1, the 1 is implicit when raising x to non-zero k,
             # so strip it.
@@ -204,7 +204,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         # eg. -         5       x^     2
         s_d = self.degree
         terms = ["{0}{1}{2}{3}".
-                 format(*components(ak, k, k==s_d))
+                 format(*components(ak, k, k == s_d))
                  for ak, k in self.terms
                  if ak != 0]
 

--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -169,13 +169,13 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
                  format(ones_removed(ak, k), k)
                  for k, ak in enumerate(self._vector)
                  if ak != 0]
-        joined_terms = " + ".join(reversed(terms))
-        replace_terms = {"x^1": "x",
+        joined_terms = " + ".join(reversed(terms)) + " "
+        replace_terms = {"x^1 ": "x",
                          "x^0": "",
                          " + -": " - "}
         for k, v in replace_terms.items():
             joined_terms = joined_terms.replace(k, v)
-        return joined_terms
+        return joined_terms[:-1]
 
     def __eq__(self, other):
         """Return self == other.

--- a/tests/test_polynomials_init.py
+++ b/tests/test_polynomials_init.py
@@ -2,7 +2,7 @@
 
 import unittest
 from polynomial import Polynomial
-
+from math import inf
 
 class TestPolynomialsInit(unittest.TestCase):
     """Defines polynomials initialization test cases."""
@@ -51,7 +51,7 @@ class TestPolynomialsInit(unittest.TestCase):
 
         a = p1 - p2
 
-        self.assertEquals(a.degree, 0)
+        self.assertEquals(a.degree, -inf)
 
     def test_polynomial_degree_goes_down_on_setitem(self):
         """Test that polynomial degree changes when the leading term is set to zero."""
@@ -60,7 +60,7 @@ class TestPolynomialsInit(unittest.TestCase):
 
         p[2] = 0
 
-        self.assertEquals(a.degree, 1)
+        self.assertEquals(p.degree, 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_init.py
+++ b/tests/test_polynomials_init.py
@@ -43,6 +43,24 @@ class TestPolynomialsInit(unittest.TestCase):
 
         self.assertEqual(p1, p2)
 
+    def test_polynomial_degree_goes_down_when_zeroed(self):
+        """Test that polynomial degree changes when subtraction sets leading term to zero."""
+        coeffs = [1, 2]
+        p1 = Polynomial(coeffs)
+        p2 = Polynomial(coeffs)
+
+        a = p1 - p2
+
+        self.assertEquals(a.degree, 0)
+
+    def test_polynomial_degree_goes_down_on_setitem(self):
+        """Test that polynomial degree changes when the leading term is set to zero."""
+        coeffs = [1, 2, 3]
+        p = Polynomial(coeffs)
+
+        p[2] = 0
+
+        self.assertEquals(a.degree, 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_str.py
+++ b/tests/test_polynomials_str.py
@@ -70,8 +70,8 @@ class TestPolynomialsStr(unittest.TestCase):
 
         self.assertEqual(expect, s)
 
-def test_power_starting_in_one_kept_if_power_is_not_one(self):
-        """Test that there is a short minus sign if the first coeff is < 0."""
+    def test_power_starting_in_one_kept_if_power_is_not_one(self):
+        """Test x^10 is not converted to x and properly appears as x^10."""
         expect = "5x^10"
 
         s = str(Monomial(5, 10))

--- a/tests/test_polynomials_str.py
+++ b/tests/test_polynomials_str.py
@@ -1,7 +1,7 @@
 """Unit-testing module defining polynomials __str__ test cases."""
 
 import unittest
-from polynomial import Polynomial, ZeroPolynomial
+from polynomial import Monomial, Polynomial, ZeroPolynomial
 
 
 class TestPolynomialsStr(unittest.TestCase):
@@ -10,81 +10,88 @@ class TestPolynomialsStr(unittest.TestCase):
     def test_smoke(self):
         """Perform a test case containing all possible complicated inputs."""
         coeffs = [0, 0, -2, 0, 4.6666666666, -(69+420j), -1, 1337]
-
-        expect_str = "-2x^5 + 4.6666666666x^3 + (-69-420j)x^2 - x + 1337"
+        expect = "-2x^5 + 4.6666666666x^3 + (-69-420j)x^2 - x + 1337"
 
         s = str(Polynomial(coeffs))
 
-        self.assertEqual(expect_str, s)
+        self.assertEqual(expect, s)
 
     def test_negative_coefficient_replaces_plus_with_minus(self):
         """Test that negative coefficients replace the + between the terms."""
         coeffs = [3, -2, 0, 0]
         expect = "3x^3 - 2x^2"
 
-        r = str(Polynomial(coeffs))
+        s = str(Polynomial(coeffs))
 
-        self.assertEqual(r, expect)
+        self.assertEqual(expect, s)
 
     def test_first_degree_term_does_not_display_variable_power(self):
         """Test that the first-degree-term ends with 'x' and not 'x^1'."""
         coeffs = [2, 0]
         expect = "2x"
 
-        r = str(Polynomial(coeffs))
+        s = str(Polynomial(coeffs))
 
-        self.assertEqual(r, expect)
+        self.assertEqual(expect, s)
 
     def test_constant_does_not_display_variable_power(self):
         """Test that the constant term does not end with 'x' or 'x^0'."""
         coeffs = [2]
         expect = "2"
 
-        r = str(Polynomial(coeffs))
+        s = str(Polynomial(coeffs))
 
-        self.assertEqual(r, expect)
+        self.assertEqual(expect, s)
 
     def test_unit_coefficient_is_not_displayed_if_not_constant(self):
         """Test that coefficients with value 1 are not displayed."""
         coeffs = [1, 2]
         expect = "x + 2"
 
-        r = str(Polynomial(coeffs))
+        s = str(Polynomial(coeffs))
 
-        self.assertEqual(r, expect)
+        self.assertEqual(expect, s)
 
     def test_unit_coefficient_is_displayed_if_constant_term(self):
         """Test that constants with value 1 are displayed properly."""
         coeffs = [1, 0, 1]
         expect = "x^2 + 1"
 
-        r = str(Polynomial(coeffs))
+        s = str(Polynomial(coeffs))
 
-        self.assertEqual(r, expect)
+        self.assertEqual(expect, s)
 
     def test_negative_coefficient_at_the_beggining_puts_short_minus(self):
         """Test that there is a short minus sign if the first coeff is < 0."""
         coeffs = [-1, 0, 2]
         expect = "-x^2 + 2"
 
-        r = str(Polynomial(coeffs))
+        s = str(Polynomial(coeffs))
 
-        self.assertEqual(r, expect)
+        self.assertEqual(expect, s)
+
+def test_power_starting_in_one_kept_if_power_is_not_one(self):
+        """Test that there is a short minus sign if the first coeff is < 0."""
+        expect = "5x^10"
+
+        s = str(Monomial(5, 10))
+
+        self.assertEqual(expect, s)
 
     def test_canonical_string(self):
         """Test with string coefficients."""
         coeffs = "abcdef"
         expect = "ax^5 + bx^4 + cx^3 + dx^2 + ex + f"
 
-        r = str(Polynomial(coeffs))
+        s = str(Polynomial(coeffs))
 
-        self.assertEqual(expect, r)
+        self.assertEqual(expect, s)
 
     def test_zero_polynomial_str_is_zero(self):
         """Test that the 0-polynomial is just '0'."""
-        r = str(ZeroPolynomial())
+        s = str(ZeroPolynomial())
 
-        self.assertEqual(r, "0")
+        self.assertEqual("0", s)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Replacing x^1 with "x" would result in issues if the true power simply started in 10, like x^10:

```
print(Monomial(5, 10))

>>> 5x0
```

Doing operations where a polynomial would lose its leading degree would result in incorrect degrees being printed:

```
a = Polynomial(1, 2) - Polynomial(1, 0)
print(a.degree)

>>> 1
```
