### PR TITLE
Implement divmod, floordiv

### DIFF
--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -384,7 +384,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
     @extract_polynomial
     def __divmod__(self, other):
         """Return divmod(self, other).
-        
+
         The remainder is any term that would have degree < 0.
         """
         if other.degree == -inf:

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -250,7 +250,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         self == 0 <==> self == Polynomial()
         """
         if other == 0:
-            return bool(self)
+            return not self
 
         return self.degree == other.degree and self.terms == other.terms
 
@@ -260,7 +260,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         self != 0 <==> self != Polynomial()
         """
         if other == 0:
-            return not self
+            return bool(self)
 
         return self.degree != other.degree and self.terms != other.terms
 
@@ -414,7 +414,10 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         while working.degree >= other.degree:
             val = working.a / other.a
             vec.append(val)
+            wd = working.degree
             working -= other * Monomial(val, working.degree - other.degree)
+            if working.degree != -inf:
+                vec.extend([0] * (wd - working.degree - 1))
 
         return Polynomial(vec), working
 

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -381,6 +381,32 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
             setattr(result, k, deepcopy(v, memo))
         return result
 
+    @extract_polynomial
+    def __divmod__(self, other):
+        """Return divmod(self, other).
+        
+        The remainder is any term that would have degree < 0.
+        """
+        if other.degree == -inf:
+            raise ZeroDivisionError("Can't divide a Polynomial by 0")
+
+        if isinstance(other, Monomial):
+            vec = self._vector[other.degree:]
+            remainder = self._vector[:other.degree]
+            for i, v in enumerate(vec):
+                vec[i] = v / other.a
+            return Polynomial(vec), Polynomial(remainder)
+
+        working = deepcopy(self)
+        vec = []
+
+        while working.degree >= other.degree:
+            val = working.a / other.a
+            vec.append(val)
+            working -= other * Monomial(val, working.degree - other.degree)
+
+        return Polynomial(vec), working
+
 
 class Monomial(Polynomial):
     """Implements a single-variable monomial. A single-term polynomial."""

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -406,7 +406,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
             remainder = self._vector[:other.degree]
             for i, v in enumerate(vec):
                 vec[i] = v / other.a
-            return Polynomial(vec), Polynomial(remainder)
+            return Polynomial(vec[::-1]), Polynomial(remainder[::-1])
 
         working = deepcopy(self)
         vec = []

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -382,6 +382,17 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         return result
 
     @extract_polynomial
+    def __ifloordiv__(self, other):
+        """Return self //= other."""
+        self.terms = divmod(self, other)[0].terms
+        return self
+
+    @extract_polynomial
+    def __floordiv__(self, other):
+        """Return self // other."""
+        return divmod(self, other)[0]
+
+    @extract_polynomial
     def __divmod__(self, other):
         """Return divmod(self, other).
 

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -263,6 +263,10 @@ class TestPolynomialsOperations(unittest.TestCase):
         self._assert_polynomials_are_the_same(z1, p3)
         self._assert_polynomials_are_the_same(z1, p4)
 
+    # Note that for the division tests, we don't use
+    # _assert_polynomials_are_the_same because an integer divided by an
+    # integer results in a float.
+
     def test_divmod_same_polynomial(self):
         """Test that divmodding two identical polynomials works correctly."""
         p1 = Polynomial(1, 4, 4)
@@ -313,6 +317,23 @@ class TestPolynomialsOperations(unittest.TestCase):
         self.assertEqual(p3, Polynomial())
         self.assertEqual(p1, remainder)
 
+    def test_inplace_floor_div(self):
+        """Test that a //= x behaves as expected."""
+        p1 = Polynomial(1, 4, 4)
+        p2 = Polynomial(1, 2)
+
+        p1 //= p2
+
+        self.assertEqual(p1, Polynomial(1, 2))
+
+    def test_floor_div(self):
+        """Test that a = b // x behaves as expected."""
+        p1 = Polynomial(1, 4, 4)
+        p2 = Polynomial(1, 2)
+
+        p3 = p1 // p2
+
+        self.assertEqual(p3, Polynomial(1, 2))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -1,7 +1,12 @@
 """Unit-testing module for testing various polynomial operations."""
 
 import unittest
-from polynomial import Polynomial, ZeroPolynomial, Constant
+from polynomial import (
+    Constant,
+    Monomial,
+    Polynomial,
+    ZeroPolynomial,
+)
 from math import inf
 
 
@@ -289,7 +294,7 @@ class TestPolynomialsOperations(unittest.TestCase):
         self.assertEqual(remainder, Polynomial(3))
 
     def test_divmod_against_constant(self):
-        """Tests that Polynomial(*) divmod a Constant leaves no remainder."""
+        """Test that Polynomial(*) divmod a Constant leaves no remainder."""
         p1 = Polynomial(1, 2, 3)
         p2 = Constant(5)
 
@@ -299,7 +304,7 @@ class TestPolynomialsOperations(unittest.TestCase):
         self.assertEqual(remainder, Polynomial())
 
     def test_divmod_against_monomial(self):
-        """Tests that Polynomial(*) divmod a larger monomial leaves polynomial."""
+        """Test that divmodding by a larger monomial leaves original val."""
         p1 = Polynomial(1, 2, 3)
         p2 = Monomial(1, 10)
 

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -258,7 +258,7 @@ class TestPolynomialsOperations(unittest.TestCase):
         self._assert_polynomials_are_the_same(z1, p3)
         self._assert_polynomials_are_the_same(z1, p4)
 
-      def test_divmod_same_polynomial(self):
+    def test_divmod_same_polynomial(self):
         """Test that divmodding two identical polynomials works correctly."""
         p1 = Polynomial(1, 4, 4)
         p2 = Polynomial(1, 4, 4)

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -335,5 +335,20 @@ class TestPolynomialsOperations(unittest.TestCase):
 
         self.assertEqual(p3, Polynomial(1, 2))
 
+    def test_eq_neq_opposite_when_equals(self):
+        """Tests that equal polynomials are truly equal."""
+        self.assertEqual(Polynomial(1, 2, 3), Polynomial(1, 2, 3))
+        self.assertFalse(Polynomial(1, 2, 3) != Polynomial(1, 2, 3))
+
+    def test_eq_neq_opposite_when_one_is_zero(self):
+        """Tests that nonzero polynomial != 0"""
+        self.assertNotEqual(Polynomial(1, 2), 0)
+        self.assertFalse(Polynomial(1, 2) == 0)
+
+    def test_eq_neq_opposite_when_both_are_zero(self):
+        """Tests that zero polynomial == 0"""
+        self.assertEquals(Polynomial(), 0)
+        self.assertFalse(Polynomial() != 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -258,6 +258,56 @@ class TestPolynomialsOperations(unittest.TestCase):
         self._assert_polynomials_are_the_same(z1, p3)
         self._assert_polynomials_are_the_same(z1, p4)
 
+      def test_divmod_same_polynomial(self):
+        """Test that divmodding two identical polynomials works correctly."""
+        p1 = Polynomial(1, 4, 4)
+        p2 = Polynomial(1, 4, 4)
+
+        p3, remainder = divmod(p1, p2)
+
+        self.assertEqual(p3, Polynomial(1))
+        self.assertEqual(remainder, Polynomial())
+
+    def test_divmod_no_remainder(self):
+        """Test that divmodding a polynomial with a factor works correctly."""
+        p1 = Polynomial(1, 4, 4)
+        p2 = Polynomial(1, 2)
+
+        p3, remainder = divmod(p1, p2)
+
+        self.assertEqual(p3, Polynomial(1, 2))
+        self.assertEqual(remainder, Polynomial())
+
+    def test_divmod_remainder_exists(self):
+        """Test that divmodding with a non-zero remainder works correctly."""
+        p1 = Polynomial(1, 2, 3)
+        p2 = Polynomial(1, 2)
+
+        p3, remainder = divmod(p1, p2)
+
+        self.assertEqual(p3, Polynomial(1, 0))
+        self.assertEqual(remainder, Polynomial(3))
+
+    def test_divmod_against_constant(self):
+        """Tests that Polynomial(*) divmod a Constant leaves no remainder."""
+        p1 = Polynomial(1, 2, 3)
+        p2 = Constant(5)
+
+        p3, remainder = divmod(p1, p2)
+
+        self.assertEqual(p3, Polynomial(1/5, 2/5, 3/5))
+        self.assertEqual(remainder, Polynomial())
+
+    def test_divmod_against_monomial(self):
+        """Tests that Polynomial(*) divmod a larger monomial leaves polynomial."""
+        p1 = Polynomial(1, 2, 3)
+        p2 = Monomial(1, 10)
+
+        p3, remainder = divmod(p1, p2)
+
+        self.assertEqual(p3, Polynomial())
+        self.assertEqual(p1, remainder)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I've implemented methods to allow the following:

```
p1, remainder = divmod(Polynomial(1, 4, 4), Polynomial(1, 2))
p1
>>> 1.0x + 2.0
remainder
>>> 0.0
p1 = Polynomial(1, 4, 4)
p1 //= Polynomial(1, 2)
p1
>>> 1.0x + 2.0
Polynomial(1, 4, 4) // Polynomial(1, 2)
>>> 1.0x + 2.0
```

This does lead to unfortunate behaviour with float division, but otherwise works well. I've decided not to implement division, as there's no good way to handle the remainder.

I also discovered that eq and neq flipped the checks for both objects being zero, and added tests to check that equality behaves as expected.