### PR TITLE
Use slicing on _vector more directly.

### DIFF
--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -174,8 +174,8 @@ class Polynomial:
     def __getitem__(self, degree):
         """Get the coefficient of the term with the given degree."""
         if isinstance(degree, slice):
-            indices = degree.indices(self.degree + 1)
-            return [self._vector[degree] for degree in range(*indices)]
+            start, stop, step = degree.indices(self.degree + 1)
+            return self._vector[start: stop: step]
 
         if degree > self.degree or degree < 0:
             raise IndexError("Attempt to get coefficient of term with \
@@ -185,9 +185,8 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
     def __setitem__(self, degree, new_value):
         """Set the coefficient of the term with the given degree."""
         if isinstance(degree, slice):
-            indices = degree.indices(self.degree + 1)
-            for deg, value in zip(range(*indices), new_value):
-                self._vector[deg] = value
+            start, stop, step = degree.indices(self.degree + 1)
+            self._vector[start: stop: step] = new_value
         elif degree > self.degree:
             raise IndexError("Attempt to set coefficient of term with \
 degree {0} of a {1}-degree polynomial".format(degree, self.degree))

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -174,8 +174,7 @@ class Polynomial:
     def __getitem__(self, degree):
         """Get the coefficient of the term with the given degree."""
         if isinstance(degree, slice):
-            start, stop, step = degree.indices(self.degree + 1)
-            return self._vector[start: stop: step]
+            return self._vector[degree]
 
         if degree > self.degree or degree < 0:
             raise IndexError("Attempt to get coefficient of term with \
@@ -185,8 +184,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
     def __setitem__(self, degree, new_value):
         """Set the coefficient of the term with the given degree."""
         if isinstance(degree, slice):
-            start, stop, step = degree.indices(self.degree + 1)
-            self._vector[start: stop: step] = new_value
+            self._vector[degree] = new_value
         elif degree > self.degree:
             raise IndexError("Attempt to set coefficient of term with \
 degree {0} of a {1}-degree polynomial".format(degree, self.degree))


### PR DESCRIPTION
Since degree is a slice, and lists implement slicing, we may as well use the output of degree.indices directly on self._vector and skip the intermediate step.