### PR TITLE
Implement __pow__, __ipow__, fix bugs when multiplying ZeroPolynomial with Monomials.

### DIFF
--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -558,7 +558,7 @@ class Monomial(Polynomial):
 
     def __pow__(self, power, modulo=None):
         """Return self ** power or pow(self, other, modulo)."""
-        result = copy(self)
+        result = deepcopy(self)
         result **= power
 
         return result % modulo if modulo is not None else result

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -470,7 +470,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         return result % modulo if modulo is not None else result
 
     def __ipow__(self, other):
-        """Returns self **= power"""
+        """Return self **= power."""
         self.terms = (self ** other).terms
         return self
 
@@ -551,6 +551,13 @@ class Monomial(Polynomial):
         if self.degree == other.degree:
             return self.a > other.a
         return self.degree > other.degree
+
+    def __ipow__(self, other):
+        """Return self **= power."""
+        if not self:
+            return self
+
+        return super().__ipow__(other)
 
     def __repr__(self):
         """Return repr(self)."""

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -454,7 +454,10 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
             )
 
         if power < 0:
-            raise ValueError("Polynomial can only be raised to a positive power.")
+            raise ValueError(
+                "Polynomial can only be raised to a positive power."
+            )
+
         if power == 0:
             result = Constant(1)
         elif power % 2 == 1:
@@ -467,6 +470,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
             else:
                 result = self ** (power // 2)
             result *= result
+
         return result % modulo if modulo is not None else result
 
     def __ipow__(self, other):

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -559,7 +559,7 @@ class Monomial(Polynomial):
     def __pow__(self, power, modulo=None):
         """Return self ** power or pow(self, other, modulo)."""
         result = copy(self)
-        return **= power
+        result **= power
 
         return result % modulo if modulo is not None else result
 

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -446,6 +446,34 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
 
         return Polynomial(vec), working
 
+    def __pow__(self, power, modulo=None):
+        """Return self ** power or pow(self, other, modulo)."""
+        if not isinstance(power, int):
+            raise ValueError(
+                "Can't call Polynomial() ** x with a non-integer type."
+            )
+
+        if power < 0:
+            raise ValueError("Polynomial can only be raised to a positive power.")
+        if power == 0:
+            result = Constant(1)
+        elif power % 2 == 1:
+            result = Polynomial(self)
+            if power > 1:
+                result *= (self ** (power // 2)) ** 2
+        else:
+            if power == 2:
+                result = self
+            else:
+                result = self ** (power // 2)
+            result *= result
+        return result % modulo if modulo is not None else result
+
+    def __ipow__(self, other):
+        """Returns self **= power"""
+        self.terms = (self ** other).terms
+        return self
+
     def __contains__(self, item):
         """Return item in self.
 

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -466,7 +466,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
                 result *= (self ** (power // 2)) ** 2
         else:
             if power == 2:
-                result = self
+                result = Polynomial(self)
             else:
                 result = self ** (power // 2)
             result *= result
@@ -556,9 +556,38 @@ class Monomial(Polynomial):
             return self.a > other.a
         return self.degree > other.degree
 
+    def __pow__(self, power, modulo=None):
+        """Return self ** power or pow(self, other, modulo)."""
+        if not isinstance(power, int):
+            raise ValueError(
+                "Can't call Monomial() ** x with a non-integer type."
+            )
+
+        if power < 0:
+            raise ValueError(
+                "Monomial can only be raised to a positive power."
+            )
+
+        if power == 0:
+            result = Constant(1)
+        elif not self:
+            result = self
+        else:
+            if isinstance(self, Constant):
+                result = Constant(self.const ** power)
+            else:
+                result = Monomial(
+                    self.coefficient ** power,
+                    self.degree * power
+                )
+
+        return result % modulo if modulo is not None else result
+
     def __ipow__(self, other):
         """Return self **= power."""
         if not self:
+            if other == 0:
+                return Constant(1)
             return self
 
         return super().__ipow__(other)

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -569,12 +569,12 @@ class Monomial(Polynomial):
         Assumes self is mutable.
         Does not mutate in the case that self == 0 and other != 1.
         """
-        if not isinstance(power, int):
+        if not isinstance(other, int):
             raise ValueError(
                 "Can't call Monomial() **= x with a non-integer type."
             )
 
-        if power < 0:
+        if other < 0:
             raise ValueError(
                 "Monomial can only be raised to a non-negative power."
             )
@@ -671,7 +671,7 @@ class ZeroPolynomial(Constant):
         if other == 0:
             return Constant(1)
 
-        # This call simplify enforces the restrictions.
+        # This call simplify enforces other >= 0 and is int.
         # Could be moved out into a decorator.
         return super().__ipow__(other)
 

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -644,6 +644,16 @@ class ZeroPolynomial(Constant):
         """Equivalent to Polynomial()."""
         Constant.__init__(self, 0)
 
+    @property
+    def const(self):
+        """Return self.const, which is always 0."""
+        return 0
+
+    @const.setter
+    def const(self, val):
+        """Block self.const being set."""
+        raise AttributeError("Can not set ZeroPolynomial.const")
+
     def __int__(self):
         """Return 0."""
         return 0

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -525,11 +525,16 @@ class Monomial(Polynomial):
     @extract_polynomial
     def __mul__(self, other):
         """Return self * other."""
+        if not self or not other:
+            return ZeroPolynomial()
         if isinstance(other, Monomial):
             return Monomial(self.a * other.a, self.degree + other.degree)
         if isinstance(other, Polynomial):
             return Polynomial(self) * other  # avoiding stack overflow
-        return self * other
+        raise ValueError(
+            "Should not reach this point - got {0}, expected Polynomial."
+            .format(type(other).__name__)
+        )
 
     @extract_polynomial
     def __rmul__(self, other):

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -490,10 +490,12 @@ class TestPolynomialsOperations(unittest.TestCase):
             expected *= p
 
     def test_setting_zero_const_raises(self):
+        """Test that doing ZeroPolynomial.const = x raises an error."""
         z = ZeroPolynomial()
         self.assertRaises(AttributeError, setattr, z, "const", None)
 
     def test_zero_const_is_zero(self):
+        """Test that ZeroPolynomial.const is always 0."""
         self.assertEqual(0, ZeroPolynomial().const)
 
 if __name__ == '__main__':

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -425,6 +425,69 @@ class TestPolynomialsOperations(unittest.TestCase):
         result = p.nth_derivative(10)
         self._assert_polynomials_are_the_same(pd, result)
 
+    def test_pow_monomial(self):
+        """Test power against various Monomial subclasses."""
+        c = Constant(5)
+        ec = Constant(25)
+        m = Monomial(5, 10)
+        em = Monomial(25, 20)
+        z = ZeroPolynomial()
+        ez = ZeroPolynomial()
+
+        self._assert_polynomials_are_the_same(ec, c ** 2)
+        self._assert_polynomials_are_the_same(em, m ** 2)
+        self._assert_polynomials_are_the_same(ez, z ** 2)
+
+    def test_pow_zero_case(self):
+        """Test pow ** 0 returns 1."""
+        one = Constant(1)
+        c = Constant(5)
+        m = Monomial(5, 10)
+        z = ZeroPolynomial()
+        p = Polynomial(1, 2, 3)
+
+        self._assert_polynomials_are_the_same(one, c ** 0)
+        self._assert_polynomials_are_the_same(one, m ** 0)
+        self._assert_polynomials_are_the_same(one, z ** 0)
+        self._assert_polynomials_are_the_same(one, p ** 0)
+
+    def test_pow_one_case(self):
+        """Tests pow ** 1 returns a copy of the polynomial."""
+        c = Constant(5)
+        m = Monomial(5, 10)
+        z = ZeroPolynomial()
+        p = Polynomial(1, 2, 3)
+
+        self._assert_polynomials_are_the_same(c, c ** 1)
+        self._assert_polynomials_are_the_same(m, m ** 1)
+        self._assert_polynomials_are_the_same(z, z ** 1)
+        self._assert_polynomials_are_the_same(p, p ** 1)
+
+    def test_pow_two_case(self):
+        """Test pow ** 2."""
+        c = Constant(5)
+        ce = Constant(25)
+        m = Monomial(5, 10)
+        z = ZeroPolynomial()
+        p = Polynomial(1, 2, 3)
+
+        # c * c returns a monomial, while the __pow__ version
+        # returns a constant.
+        self._assert_polynomials_are_the_same(ce, c ** 2)
+        self._assert_polynomials_are_the_same(m * m, m ** 2)
+        self._assert_polynomials_are_the_same(z * z, z ** 2)
+        self._assert_polynomials_are_the_same(p * p, p ** 2)
+
+    def test_general_pow(self):
+        """Check that pow returns the expected value."""
+        p = Polynomial(1, 2)
+        expected = Polynomial(p)
+
+        for i in range(1, 10):
+            res = p ** i
+            self._assert_polynomials_are_the_same(expected, res)
+            self.assertNotIs(p, res)
+            expected *= p
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -441,13 +441,14 @@ class TestPolynomialsOperations(unittest.TestCase):
     def test_pow_zero_case(self):
         """Test pow ** 0 returns 1."""
         one = Constant(1)
+        m_one = Monomial(1, 0)
         c = Constant(5)
         m = Monomial(5, 10)
         z = ZeroPolynomial()
         p = Polynomial(1, 2, 3)
 
         self._assert_polynomials_are_the_same(one, c ** 0)
-        self._assert_polynomials_are_the_same(one, m ** 0)
+        self._assert_polynomials_are_the_same(m_one, m ** 0)
         self._assert_polynomials_are_the_same(one, z ** 0)
         self._assert_polynomials_are_the_same(one, p ** 0)
 
@@ -466,14 +467,11 @@ class TestPolynomialsOperations(unittest.TestCase):
     def test_pow_two_case(self):
         """Test pow ** 2."""
         c = Constant(5)
-        ce = Constant(25)
         m = Monomial(5, 10)
         z = ZeroPolynomial()
         p = Polynomial(1, 2, 3)
 
-        # c * c returns a monomial, while the __pow__ version
-        # returns a constant.
-        self._assert_polynomials_are_the_same(ce, c ** 2)
+        self._assert_polynomials_are_the_same(c * c, c ** 2)
         self._assert_polynomials_are_the_same(m * m, m ** 2)
         self._assert_polynomials_are_the_same(z * z, z ** 2)
         self._assert_polynomials_are_the_same(p * p, p ** 2)

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -486,7 +486,7 @@ class TestPolynomialsOperations(unittest.TestCase):
         for i in range(1, 10):
             res = p ** i
             self._assert_polynomials_are_the_same(expected, res)
-            self.assertNotIs(p, res)
+            self.assertIsNot(p, res)
             expected *= p
 
 if __name__ == '__main__':

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -489,5 +489,12 @@ class TestPolynomialsOperations(unittest.TestCase):
             self.assertIsNot(p, res)
             expected *= p
 
+    def test_setting_zero_const_raises(self):
+        z = ZeroPolynomial()
+        self.assertRaises(AttributeError, setattr, z, "const", None)
+
+    def test_zero_const_is_zero(self):
+        self.assertEqual(0, ZeroPolynomial().const)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This implements `__pow__`, `__ipow__`:

```
Polynomial(1, 2) ** 2
>>> x^2 + 4x + 4
Polynomial(1, 2, 3) ** 3
>>> x^6 + 6x^5 + 21x^4 + 44x^3 + 63x^2 + 54x + 27
Polynomial(*range(1, 11)) ** 0
>>> 1
a = Polynomial(1, 2)
a **= 2
a
>>> x^2 + 4x + 4
Polynomial(*range(1, 11)) ** 1
>>> x^9 + 2x^8 + 3x^7 + 4x^6 + 5x^5 + 6x^4 + 7x^3 + 8x^2 + 9x + 10
Constant(5) ** 2
>>> 25
Monomial(5, 10) ** 2
>>> 25x^20
ZeroPolynomial() ** 5
>>> 0
```

Original behaviour for zero-polynomial multiplication:
```
ZeroPolynomial() * ZeroPolynomial()
>>> ...
>>> IndexError: Attempt to get coefficient of term with degree -inf of a -inf-degree polynomial
Monomial() * ZeroPolynomial()
>>> ...
>>> IndexError: Attempt to get coefficient of term with degree -inf of a -inf-degree polynomial
```

New behaviour:
```
ZeroPolynomial() * ZeroPolynomial()
>>> 0
Monomial() * ZeroPolynomial()
>>> 0
```

This does have some issues with subclassing, since you want the Polynomial methods to be generic and you'd expect Monomial instances of pow would return Monomials / Constants. I feel like Monomial should not subclass from Polynomial, in order to better ensure that it remains internally consistent (eg. might call a Polynomial() method that modifies terms in place, and it uses a lot more space due to _vector, which isn't really necessary.)

Additionally, it seems that ZeroPolynomial does not match expectations when it comes to defining a - should this be guarenteed to return 0 if degree is -inf, or should we get rid of all .a calls in Monomials?