### PR TITLE
Simplify multiplication, make Constant Constant multiplies return Constant

### DIFF
--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -561,11 +561,6 @@ class Constant(Monomial):
 
         return super().__mul__(other)
 
-    @extract_polynomial
-    def __rmul__(self, other):
-        """Return other * self."""
-        return self * other
-
     def __int__(self):
         """Return int(self)."""
         return int(self.const)

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -495,9 +495,7 @@ class Monomial(Polynomial):
         """Return self * other."""
         if isinstance(other, Monomial):
             return Monomial(self.a * other.a, self.degree + other.degree)
-        if isinstance(other, Polynomial):
-            return Polynomial(self) * other  # avoiding stack overflow
-        return self * other
+        return super().__mul__(other)
 
     @extract_polynomial
     def __rmul__(self, other):
@@ -551,6 +549,22 @@ class Constant(Monomial):
     def const(self, val):
         """Set the constant term."""
         self._vector[0] = val
+
+    @extract_polynomial
+    def __mul__(self, other):
+        """Return self * other."""
+        if not self or not other:
+            return ZeroPolynomial()
+
+        if isinstance(other, Constant):
+            return Constant(self.const * other.const)
+
+        return super().__mul__(other)
+
+    @extract_polynomial
+    def __rmul__(self, other):
+        """Return other * self."""
+        return self * other
 
     def __int__(self):
         """Return int(self)."""

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -426,6 +426,7 @@ class TestPolynomialsOperations(unittest.TestCase):
         self._assert_polynomials_are_the_same(pd, result)
 
    def test_constant_constant_mul_yields_constant(self):
+        """Test that Constant * Constant yields Constant."""
         c = Constant(5)
         expected = Constant(25)
         self._assert_polynomials_are_the_same(expected, c * c)

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -425,6 +425,10 @@ class TestPolynomialsOperations(unittest.TestCase):
         result = p.nth_derivative(10)
         self._assert_polynomials_are_the_same(pd, result)
 
+   def test_constant_constant_mul_yields_constant(self):
+        c = Constant(5)
+        expected = Constant(25)
+        self._assert_polynomials_are_the_same(expected, c * c)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -425,7 +425,7 @@ class TestPolynomialsOperations(unittest.TestCase):
         result = p.nth_derivative(10)
         self._assert_polynomials_are_the_same(pd, result)
 
-   def test_constant_constant_mul_yields_constant(self):
+    def test_constant_constant_mul_yields_constant(self):
         """Test that Constant * Constant yields Constant."""
         c = Constant(5)
         expected = Constant(25)


### PR DESCRIPTION
I think that where ever possible, we should return the same type as was passed in, as to maintain expected behaviour (eg. you'd expect `Constant(5) * 5` to be `Constant(25)`).

Old behaviour:
```
repr(Constant(5) * 5)
>>> Polynomial(25)
```

New behaviour:
```
repr(Constant(5) * 5)
>>> Constant(25)
repr(Constant(5) * Constant(5))
>>> Constant(25)
```