### PR TITLE
Fix repr for Binomial, Trinomial

### DIFF
--- a/polynomial/binomial.py
+++ b/polynomial/binomial.py
@@ -18,6 +18,16 @@ class Binomial(Polynomial):
             monomial2 = Monomial(1, 2)
         Polynomial.__init__(self, [monomial1, monomial2], from_monomials=True)
 
+    def __repr__(self):
+        """Return repr(self)."""
+        terms = self.terms
+        assert len(terms) == 2
+        t1, t2 = terms
+        return (
+            "Binomial(Monomial({0}, {1}), Monomial({2}, {3}))"
+            .format(*t1, *t2)
+        )
+
 
 class LinearBinomial(Binomial):
     """Implements linear binomials and their methods."""

--- a/polynomial/trinomial.py
+++ b/polynomial/trinomial.py
@@ -25,6 +25,17 @@ class Trinomial(Polynomial):
         args = [monomial1, monomial2, monomial3]
         Polynomial.__init__(self, args, from_monomials=True)
 
+    def __repr__(self):
+        """Return repr(self)."""
+        terms = self.terms
+        assert len(terms) == 3
+        t1, t2, t3 = terms
+        return (
+            "Trinomial(Monomial({0}, {1}), Monomial({2}, {3}), "
+            "Monomial({4}, {5}))"
+            .format(*t1, *t2, *t3)
+        )
+
 
 class QuadraticTrinomial(Trinomial):
     """Implements quadratic trinomials and their related methods."""

--- a/tests/test_polynomials_repr.py
+++ b/tests/test_polynomials_repr.py
@@ -1,6 +1,9 @@
 """Unit-testing module defining polynomials __repr__ test cases."""
 
+import inspect
 import unittest
+
+import polynomial
 from polynomial import (
     Constant,
     LinearBinomial,
@@ -8,7 +11,9 @@ from polynomial import (
     Polynomial,
     QuadraticTrinomial,
     ZeroPolynomial,
-    FrozenPolynomial
+    FrozenPolynomial,
+    Trinomial,
+    Binomial
 )
 
 
@@ -55,11 +60,27 @@ class TestPolynomialsRepr(unittest.TestCase):
 
         self.assertEqual(expect, r)
 
+    def test_binomial(self):
+        """Test that repr() output of a Binomial is valid."""
+        expect = "Binomial(Monomial(4, 3), Monomial(2, 1))"
+
+        r = repr(Binomial((4, 3), (2, 1)))
+
+        self.assertEqual(expect, r)
+
     def test_linear_binomial(self):
         """Test that repr() output of a LinearBinomial is valid."""
         expect = "LinearBinomial(5, 2)"
 
         r = repr(LinearBinomial(5, 2))
+
+        self.assertEqual(expect, r)
+
+    def test_trinomial(self):
+        """Test that repr() output of a Trinomial is valid."""
+        expect = "Trinomial(Monomial(5, 5), Monomial(2, 3), Monomial(1, 1))"
+
+        r = repr(Trinomial((5, 5), (2, 3), (1, 1)))
 
         self.assertEqual(expect, r)
 
@@ -79,10 +100,7 @@ class TestPolynomialsRepr(unittest.TestCase):
         self.assertEqual(expect, r)
 
     def test_all_reprs_start_correctly(self):
-        """Automatically tests that the repr of a class starts correctly."""
-        import inspect
-        import polynomial
-        print(dir(polynomial))
+        """Test that the repr of all classes start correctly."""
         for cls_str in dir(polynomial):
             cls = getattr(polynomial, cls_str)
             if not inspect.isclass(cls):

--- a/tests/test_polynomials_repr.py
+++ b/tests/test_polynomials_repr.py
@@ -78,6 +78,22 @@ class TestPolynomialsRepr(unittest.TestCase):
         r = repr(FrozenPolynomial(1, 2, 3))
         self.assertEqual(expect, r)
 
+    def test_all_reprs_start_correctly(self):
+        """Automatically tests that the repr of a class starts correctly."""
+        import inspect
+        import polynomial
+        print(dir(polynomial))
+        for cls_str in dir(polynomial):
+            cls = getattr(polynomial, cls_str)
+            if not inspect.isclass(cls):
+                continue
+            if not issubclass(cls, Polynomial):
+                continue
+            self.assertTrue(
+                repr(cls()).startswith(cls_str),
+                "{0} should start with {1}".format(repr(cls()), cls_str)
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes `__repr__` for Binomial, Trinomial, and also adds code to check that all subclasses of Polynomial have defined `__repr__` appropriately.