### PR TITLE
Implement FixedDegreePolynomial

### DIFF
--- a/polynomial/__init__.py
+++ b/polynomial/__init__.py
@@ -5,6 +5,7 @@
 
 from .core import (
     Constant,
+    DegreeError,
     Monomial,
     Polynomial,
 )

--- a/polynomial/binomial.py
+++ b/polynomial/binomial.py
@@ -1,6 +1,6 @@
 """This module defines different types of binomials and their methods."""
 
-from polynomial.core import Polynomial, Monomial
+from polynomial.core import Polynomial, Monomial, FixedDegreePolynomial
 
 
 class Binomial(Polynomial):
@@ -29,7 +29,7 @@ class Binomial(Polynomial):
         )
 
 
-class LinearBinomial(Binomial):
+class LinearBinomial(Binomial, FixedDegreePolynomial):
     """Implements linear binomials and their methods."""
 
     def __init__(self, a=1, b=1):

--- a/polynomial/binomial.py
+++ b/polynomial/binomial.py
@@ -18,6 +18,16 @@ class Binomial(Polynomial):
             monomial2 = Monomial(1, 2)
         Polynomial.__init__(self, [monomial1, monomial2], from_monomials=True)
 
+    def __repr__(self):
+        """Return repr(self)."""
+        terms = self.terms
+        assert len(terms) == 2
+        t1, t2 = terms
+        return (
+            "Binomial(Monomial({0}, {1}), Monomial({2}, {3}))"
+            .format(*t1, *t2)
+        )
+
 
 class LinearBinomial(Binomial):
     """Implements linear binomials and their methods."""

--- a/polynomial/binomial.py
+++ b/polynomial/binomial.py
@@ -29,7 +29,7 @@ class Binomial(Polynomial):
         )
 
 
-class LinearBinomial(Binomial, FixedDegreePolynomial):
+class LinearBinomial(Binomial, FixedDegreePolynomial, valid_degrees=1):
     """Implements linear binomials and their methods."""
 
     def __init__(self, a=1, b=1):

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -566,6 +566,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
 
 
 class DegreeError(Exception):
+    """Raised when a Polynomial's degree changes."""
     pass
 
 
@@ -604,6 +605,7 @@ def check_degree_constant(fallback):
 
 
 def setattr_decorator(_setattr):
+    """A decorator to allow __setattr__ to behave as expected."""
     check_deg_setattr = check_degree_constant(Polynomial.__setattr__)(_setattr)
 
     def decorator(self, name, new_value):
@@ -623,7 +625,7 @@ class FixedDegreePolynomial(Polynomial):
     )
 
     def __init_subclass__(cls, **kwargs):
-        """Init a subclass of self. """
+        """Init a subclass of self."""
         __init__ = cls.__init__
         for attr in dir(cls):
             val = getattr(cls, attr)

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -1,5 +1,5 @@
 """This module defines mutable polynomials, monomials and constants."""
-
+import inspect
 from copy import deepcopy
 from math import inf
 import string
@@ -87,14 +87,6 @@ class Polynomial:
         else:
             self._vector = iterable[::-1]
             self._trim()
-
-    @classmethod
-    def from_terms(cls, terms):
-        """Tries to create an instance of cls from terms if possible.
-
-        If not possible, creates an instance of cls's parent.
-        """
-        return Polynomial(terms, from_monomials=True)
 
     @classmethod
     def zero_instance(cls):
@@ -692,16 +684,6 @@ class Monomial(Polynomial):
         Polynomial.__init__(self, coeffs)
 
     @classmethod
-    def from_terms(cls, terms):
-        """Tries to create an instance of cls from terms if possible.
-
-        If not possible, creates an instance of cls's parent.
-        """
-        if len(terms) == 1:
-            return Monomial(*terms[0])
-        return super().from_terms(terms)
-
-    @classmethod
     def zero_instance(cls):
         """Return the Monomial which is 0."""
         return Monomial(0, 0)
@@ -844,20 +826,6 @@ class Constant(Monomial, FixedDegreePolynomial, valid_degrees=(0, -inf)):
     def __init__(self, const=1):
         """Initialize the constant with value const."""
         Monomial.__init__(self, const, 0)
-
-    @classmethod
-    def from_terms(cls, terms):
-        """Tries to create an instance of cls from terms if possible.
-
-        If not possible, creates an instance of cls's parent.
-        """
-        if len(terms) == 1:
-            term = terms[0]
-            if term[0] == 0 or term[1] == -inf:
-                return cls.zero_instance()
-            if term[1] == 0:
-                return Constant(term[0])
-        return super().from_terms(terms)
 
     @classmethod
     def zero_instance(cls):

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -554,7 +554,7 @@ class DegreeError(Exception):
     """Raised when a Polynomial's degree changes."""
 
 
-def check_degree_is_valid(fallback, valid_degrees):
+def check_degree_is_valid(fallback):
     """Check if the degree is valid and respond accordingly.
 
     If self.degree changes, we upcast to a Polynomial and try
@@ -601,7 +601,7 @@ class FixedDegreePolynomial(Polynomial):
             val = getattr(cls, attr)
             if callable(val) and attr in cls.self_mutating:
                 poly_attr = getattr(Polynomial, attr)
-                setattr(cls, attr, check_degree_is_valid(poly_attr, deg)(val))
+                setattr(cls, attr, check_degree_is_valid(poly_attr)(val))
 
         cls.__setitem__ = FixedDegreePolynomial.__setitem__
         cls.__setattr__ = FixedDegreePolynomial.__setattr__

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -289,6 +289,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
 
         return " ".join(terms)
 
+    @extract_polynomial
     def __eq__(self, other):
         """Return self == other.
 
@@ -299,6 +300,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
 
         return self.degree == other.degree and self.terms == other.terms
 
+    @extract_polynomial
     def __ne__(self, other):
         """Return self != other.
 
@@ -307,7 +309,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         if other == 0:
             return bool(self)
 
-        return self.degree != other.degree and self.terms != other.terms
+        return self.degree != other.degree or self.terms != other.terms
 
     def __bool__(self):
         """Return True if self is not a zero polynomial, otherwise False."""
@@ -371,7 +373,7 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
     def __pos__(self):
         """Return +self."""
         self._trim()
-        return self
+        return deepcopy(self)
 
     def __neg__(self):
         """Return -self."""

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -50,7 +50,7 @@ class Polynomial:
     """Implements a single-variable mathematical polynomial."""
 
     @accepts_many_arguments
-    def __init__(self, iterable=None, from_monomials=False):
+    def __init__(self, iterable, from_monomials=False):
         """Initialize the polynomial.
 
         iterable ::= the coefficients from the highest degree term
@@ -68,9 +68,6 @@ class Polynomial:
         Polynomial([(1,4), (2,3), (3,2), (4,1), (5,0)], from_monomials=True)
         Polynomial(((i + 1, 4 - i) for i in range(5)), from_monomials=True)
         """
-        if iterable is None:
-            iterable = []
-
         iterable = list(iterable)
 
         if from_monomials:
@@ -178,16 +175,12 @@ class Polynomial:
         self._trim()
 
     @property
-    def monomials(self, reverse=True):
+    def monomials(self):
         """Return a list with all terms in the form of monomials.
 
-        List is sorted from the highest degree term to the lowest
-        by default.
+        List is sorted from the highest degree term to the lowest.
         """
-        if reverse:
-            return [Monomial(k, deg) for k, deg in self.terms]
-
-        return [Monomial(k, deg) for k, deg in reversed(self.terms)]
+        return [Monomial(k, deg) for k, deg in self.terms]
 
     def calculate(self, x):
         """Calculate the value of the polynomial at a given point."""
@@ -230,8 +223,14 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         """Set the coefficient of the term with the given degree."""
         if isinstance(degree, slice):
             self._vector[degree] = new_value
-        if degree == -inf and self.degree == -inf:
-            self._vector = [new_value]
+        elif degree == -inf:
+            if self.degree == -inf:
+                self._vector = [new_value]
+            else:
+                raise IndexError(
+                    "Can not set term with degree -inf on a"
+                    " non-zero polynomial."
+                )
         elif degree > self.degree:
             raise IndexError("Attempt to set coefficient of term with \
 degree {0} of a {1}-degree polynomial".format(degree, self.degree))

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -577,10 +577,7 @@ def check_degree_is_valid(fallback, valid_degrees):
     """
     def retry_op(self, orig_terms, *args, **kwargs):
         """Reset self and retry operation on Polynomial."""
-        try:
-            self.terms = orig_terms
-        except DegreeError:
-            pass
+        self.terms = orig_terms
         self = Polynomial(self.terms, from_monomials=True)
         return fallback(self, *args, **kwargs)
 
@@ -597,7 +594,8 @@ def check_degree_is_valid(fallback, valid_degrees):
             if self.degree in valid_degrees:
                 return ret_val
 
-            # If we do something that modifies self._vector
+            # We have modified self but we have returned something else
+            # This should never happen, and should always raise an error.
             if ret_val is not self:
                 # Changing self is undefined behaviour at this point.
                 raise ValueError("Can not recover from error.")

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -1,5 +1,4 @@
 """This module defines mutable polynomials, monomials and constants."""
-import inspect
 from copy import deepcopy
 from math import inf
 import string
@@ -603,7 +602,9 @@ def check_degree_is_valid(fallback, valid_degrees):
 def setattr_decorator(degree):
     """Decorate __setattr__ to handle single variable modifications."""
     def wrapper(_setattr):
-        check_deg_setattr = check_degree_is_valid(Polynomial.__setattr__, degree)(_setattr)
+        check_deg_setattr = check_degree_is_valid(
+            Polynomial.__setattr__, degree
+        )(_setattr)
 
         def decorator(self, name, new_value):
             if len(name) == 1:

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -576,7 +576,7 @@ def check_degree_constant(fallback):
     calling the provided fallback method.
     """
     def retry_op(self, orig_terms, *args, **kwargs):
-        """Resets self and tries rerunning on Polynomial."""
+        """Reset self and retry operation on Polynomial."""
         try:
             self.terms = orig_terms
         except DegreeError:

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -606,8 +606,8 @@ class FixedDegreePolynomial(Polynomial):
         __xsetattr__ = cls.__setattr__
 
         # Methods are defined inline to allow using the class's original
-        # __setitem__ / __setattr__ calls (eg. for Freezable, and later,
-        # FixedTermPolynomial (which would have a fixed number of terms)).
+        # __setattr__ calls (eg. for Freezable, and later, FixedTermPolynomial
+        # (which would have a fixed number of terms)).
 
         def __setattr__(self, key, value):
             """Implement self.key = value."""

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -631,7 +631,6 @@ class FixedDegreePolynomial(Polynomial):
 
     def __init_subclass__(cls, **kwargs):
         """Init a subclass of self."""
-        __init__ = cls.__init__
         for attr in dir(cls):
             val = getattr(cls, attr)
             if callable(val) and attr in cls.self_mutating:
@@ -639,7 +638,6 @@ class FixedDegreePolynomial(Polynomial):
                 setattr(cls, attr, check_degree_constant(poly_attr)(val))
 
         cls.__setattr__ = setattr_decorator(cls.__setattr__)
-        cls.__init__ = __init__
         cls.terms = FixedDegreePolynomial.terms
 
     @property

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -603,16 +603,11 @@ class FixedDegreePolynomial(Polynomial):
                 poly_attr = getattr(Polynomial, attr)
                 setattr(cls, attr, check_degree_is_valid(poly_attr)(val))
 
-        __xsetitem__ = cls.__setitem__
         __xsetattr__ = cls.__setattr__
 
         # Methods are defined inline to allow using the class's original
         # __setitem__ / __setattr__ calls (eg. for Freezable, and later,
         # FixedTermPolynomial (which would have a fixed number of terms)).
-        def __setitem__(self, key, value):
-            __xsetitem__(self, key, value)
-            if self.degree not in self.valid_degrees:
-                raise DegreeError("Set self._vector to an invalid state.")
 
         def __setattr__(self, key, value):
             """Implement self.key = value."""
@@ -636,7 +631,6 @@ class FixedDegreePolynomial(Polynomial):
                     raise DegreeError("Set self._vector to an invalid state.")
                 self._trim = xtrim
 
-        cls.__setitem__ = __setitem__
         cls.__setattr__ = __setattr__
         cls.terms = FixedDegreePolynomial.terms
 

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -89,6 +89,14 @@ class Polynomial:
             self._trim()
 
     @classmethod
+    def from_terms(cls, terms):
+        """Tries to create an instance of cls from terms if possible.
+
+        If not possible, creates an instance of cls's parent.
+        """
+        return Polynomial(terms, from_monomials=True)
+
+    @classmethod
     def zero_instance(cls):
         """Return the Polynomial which is 0."""
         return Polynomial()
@@ -684,6 +692,16 @@ class Monomial(Polynomial):
         Polynomial.__init__(self, coeffs)
 
     @classmethod
+    def from_terms(cls, terms):
+        """Tries to create an instance of cls from terms if possible.
+
+        If not possible, creates an instance of cls's parent.
+        """
+        if len(terms) == 1:
+            return Monomial(*terms[0])
+        return super().from_terms(terms)
+
+    @classmethod
     def zero_instance(cls):
         """Return the Monomial which is 0."""
         return Monomial(0, 0)
@@ -826,6 +844,25 @@ class Constant(Monomial, FixedDegreePolynomial, valid_degrees=(0, -inf)):
     def __init__(self, const=1):
         """Initialize the constant with value const."""
         Monomial.__init__(self, const, 0)
+
+    @classmethod
+    def from_terms(cls, terms):
+        """Tries to create an instance of cls from terms if possible.
+
+        If not possible, creates an instance of cls's parent.
+        """
+        if len(terms) == 1:
+            term = terms[0]
+            if term[0] == 0 or term[1] == -inf:
+                return cls.zero_instance()
+            if term[1] == 0:
+                return Constant(term[0])
+        return super().from_terms(terms)
+
+    @classmethod
+    def zero_instance(cls):
+        """Return the constant which is 0."""
+        return Constant(0)
 
     def __eq__(self, other):
         """Return self == other."""

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -395,22 +395,6 @@ degree {0} of a {1}-degree polynomial".format(degree, self.degree))
         self.terms = result.terms
         return self
 
-    def __copy__(self):
-        """Create a shallow copy of self. _vector is not copied."""
-        cls = self.__class__
-        result = cls.__new__(cls)
-        result.__dict__.update(self.__dict__)
-        return result
-
-    def __deepcopy__(self, memo):
-        """Create a deep copy of self."""
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memo[id(self)] = result
-        for k, v in self.__dict__.items():
-            setattr(result, k, deepcopy(v, memo))
-        return result
-
     @extract_polynomial
     def __ifloordiv__(self, other):
         """Return self //= other."""

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -574,7 +574,7 @@ def check_degree_is_valid(fallback, valid_degrees):
     def retry_op(self, orig_terms, *args, **kwargs):
         """Reset self and retry operation on Polynomial."""
         self.terms = orig_terms
-        self = Polynomial.from_terms(self.terms)
+        self = Polynomial(self.terms, from_monomials=True)
         return fallback(self, *args, **kwargs)
 
     def wrapper(method):

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -570,21 +570,13 @@ def check_degree_is_valid(fallback, valid_degrees):
         def decorator(self, *args, **kwargs):
             orig_terms = self.terms
             try:
-                ret_val = method(self, *args, **kwargs)
+                return method(self, *args, **kwargs)
             # If we directly modify self.terms
             except DegreeError:
-                # May have tried to set a bad degree.
+                # This is done in the expectation that we're calling from
+                # FixedDegreePolynomial, which will always raise a
+                # DegreeError through __setattr__, __setitem__.
                 return retry_op(self, orig_terms, *args, **kwargs)
-
-            if self.degree in valid_degrees:
-                return ret_val
-
-            # We have modified self but we have returned something else
-            # This should never happen, and should always raise an error.
-            if ret_val is not self:
-                # Changing self is undefined behaviour at this point.
-                raise ValueError("Can not recover from error.")
-            return retry_op(self, orig_terms, *args, **kwargs)
         return decorator
     return wrapper
 

--- a/polynomial/frozen.py
+++ b/polynomial/frozen.py
@@ -1,5 +1,6 @@
 """This module defines the Freezable interface and subclasses."""
-from polynomial.core import Constant, Polynomial, extract_polynomial
+from math import inf
+from polynomial.core import Constant, Polynomial, extract_polynomial, FixedDegreePolynomial
 
 
 class Freezable:
@@ -56,7 +57,7 @@ class FrozenPolynomial(Freezable, Polynomial):
         return "Frozen" + super().__repr__()
 
 
-class ZeroPolynomial(Freezable, Constant):
+class ZeroPolynomial(Freezable, Constant, FixedDegreePolynomial, valid_degrees=-inf):
     """The zero polynomial."""
 
     def __init__(self):

--- a/polynomial/frozen.py
+++ b/polynomial/frozen.py
@@ -96,7 +96,8 @@ class ZeroPolynomial(Freezable, Constant, FixedDegreePolynomial, valid_degrees=-
 
         # This call simply enforces other >= 0 and is int.
         # Could be moved out into a decorator.
-        return super().__ipow__(other)
+        super().__ipow__(other)
+        return ZeroPolynomial()
 
     def __repr__(self):
         """Return repr(self)."""

--- a/polynomial/frozen.py
+++ b/polynomial/frozen.py
@@ -1,6 +1,10 @@
 """This module defines the Freezable interface and subclasses."""
 from math import inf
-from polynomial.core import Constant, Polynomial, extract_polynomial, FixedDegreePolynomial
+from polynomial.core import (
+    Constant,
+    Polynomial,
+    extract_polynomial,
+)
 
 
 class Freezable:
@@ -57,7 +61,7 @@ class FrozenPolynomial(Freezable, Polynomial):
         return "Frozen" + super().__repr__()
 
 
-class ZeroPolynomial(Freezable, Constant, FixedDegreePolynomial, valid_degrees=-inf):
+class ZeroPolynomial(Freezable, Constant, valid_degrees=-inf):
     """The zero polynomial."""
 
     def __init__(self):

--- a/polynomial/frozen.py
+++ b/polynomial/frozen.py
@@ -93,7 +93,7 @@ class ZeroPolynomial(Freezable, Constant):
         if other == 0:
             return Constant(1)
 
-        # This call simplify enforces other >= 0 and is int.
+        # This call simply enforces other >= 0 and is int.
         # Could be moved out into a decorator.
         return super().__ipow__(other)
 

--- a/polynomial/frozen.py
+++ b/polynomial/frozen.py
@@ -32,6 +32,9 @@ class Freezable:
         else:
             raise AttributeError("Can not modify frozen object.")
 
+    def _no_op(self):
+        """Do nothing. Used as a dummy method."""
+
 
 class FrozenPolynomial(Freezable, Polynomial):
     """A polynomial which can not be directly modified."""
@@ -53,9 +56,6 @@ class FrozenPolynomial(Freezable, Polynomial):
         """Create a frozen copy of the polynomial."""
         return cls(polynomial)
 
-    def _no_op(self):
-        """Do nothing. Used as a dummy method."""
-
     def __repr__(self):
         """Return repr(self)."""
         return "Frozen" + super().__repr__()
@@ -68,6 +68,7 @@ class ZeroPolynomial(Freezable, Constant, valid_degrees=-inf):
         """Equivalent to Polynomial()."""
         Constant.__init__(self, 0)
         self._vector = tuple(self._vector)
+        self._trim = self._no_op
         self._freeze()
 
     @classmethod

--- a/polynomial/trinomial.py
+++ b/polynomial/trinomial.py
@@ -1,6 +1,11 @@
 """This module defines different types of trinomials and their methods."""
 
-from polynomial.core import Polynomial, Monomial, Constant, FixedDegreePolynomial
+from polynomial.core import (
+    Polynomial,
+    Monomial,
+    Constant,
+    FixedDegreePolynomial
+)
 from math import sqrt
 
 

--- a/polynomial/trinomial.py
+++ b/polynomial/trinomial.py
@@ -42,7 +42,7 @@ class Trinomial(Polynomial):
         )
 
 
-class QuadraticTrinomial(Trinomial, FixedDegreePolynomial):
+class QuadraticTrinomial(Trinomial, FixedDegreePolynomial, valid_degrees=2):
     """Implements quadratic trinomials and their related methods."""
 
     def __init__(self, a=1, b=1, c=1):

--- a/polynomial/trinomial.py
+++ b/polynomial/trinomial.py
@@ -1,6 +1,6 @@
 """This module defines different types of trinomials and their methods."""
 
-from polynomial.core import Polynomial, Monomial, Constant
+from polynomial.core import Polynomial, Monomial, Constant, FixedDegreePolynomial
 from math import sqrt
 
 
@@ -37,7 +37,7 @@ class Trinomial(Polynomial):
         )
 
 
-class QuadraticTrinomial(Trinomial):
+class QuadraticTrinomial(Trinomial, FixedDegreePolynomial):
     """Implements quadratic trinomials and their related methods."""
 
     def __init__(self, a=1, b=1, c=1):
@@ -84,7 +84,7 @@ class QuadraticTrinomial(Trinomial):
     def real_factors(self):
         """Return (self,) if D < 0. Return the factors otherwise."""
         if self.discriminant < 0:
-            return (self,)
+            return self,
         return self.complex_factors
 
     def __repr__(self):

--- a/polynomial/trinomial.py
+++ b/polynomial/trinomial.py
@@ -89,7 +89,7 @@ class QuadraticTrinomial(Trinomial, FixedDegreePolynomial):
     def real_factors(self):
         """Return (self,) if D < 0. Return the factors otherwise."""
         if self.discriminant < 0:
-            return self,
+            return (self,)
         return self.complex_factors
 
     def __repr__(self):

--- a/polynomial/trinomial.py
+++ b/polynomial/trinomial.py
@@ -25,6 +25,17 @@ class Trinomial(Polynomial):
         args = [monomial1, monomial2, monomial3]
         Polynomial.__init__(self, args, from_monomials=True)
 
+    def __repr__(self):
+        """Return repr(self)."""
+        terms = self.terms
+        assert len(terms) == 3
+        t1, t2, t3 = terms
+        return (
+            "Trinomial(Monomial({0}, {1}), Monomial({2}, {3}), "
+            "Monomial({4}, {5}))"
+            .format(*t1, *t2, *t3)
+        )
+
 
 class QuadraticTrinomial(Trinomial):
     """Implements quadratic trinomials and their related methods."""

--- a/tests/test_polynomials_init.py
+++ b/tests/test_polynomials_init.py
@@ -160,6 +160,11 @@ class TestPolynomialsInit(unittest.TestCase):
         """Test that QuadraticTrinomial(0, ?) raises a ValueError."""
         self.assertRaises(ValueError, QuadraticTrinomial, 0, 1)
 
+    def test_monomial_degree_positive_int(self):
+        """Test that monomial only accepts a positive int."""
+        self.assertRaises(ValueError, Monomial, 1, -1)
+        self.assertRaises(ValueError, Monomial, 1, 1.2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_init.py
+++ b/tests/test_polynomials_init.py
@@ -152,6 +152,14 @@ class TestPolynomialsInit(unittest.TestCase):
 
         self.assertEqual(expected, qt)
 
+    def test_linear_binomial_fails_leading_zero(self):
+        """Test that LinearBinomial(0, ?) raises a ValueError."""
+        self.assertRaises(ValueError, LinearBinomial, 0, 1)
+
+    def test_quadratic_trinomial_fails_leading_zero(self):
+        """Test that QuadraticTrinomial(0, ?) raises a ValueError."""
+        self.assertRaises(ValueError, QuadraticTrinomial, 0, 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_init.py
+++ b/tests/test_polynomials_init.py
@@ -165,6 +165,9 @@ class TestPolynomialsInit(unittest.TestCase):
         self.assertRaises(ValueError, Monomial, 1, -1)
         self.assertRaises(ValueError, Monomial, 1, 1.2)
 
+    def test_polynomial_with_non_monomial_terms(self):
+        """Test that Polynomial from monomials with > 2 tuples fails."""
+        self.assertRaises(TypeError, Polynomial, [(1, 2, 3)], from_monomials=True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_init.py
+++ b/tests/test_polynomials_init.py
@@ -167,7 +167,12 @@ class TestPolynomialsInit(unittest.TestCase):
 
     def test_polynomial_with_non_monomial_terms(self):
         """Test that Polynomial from monomials with > 2 tuples fails."""
-        self.assertRaises(TypeError, Polynomial, [(1, 2, 3)], from_monomials=True)
+        self.assertRaises(
+            TypeError,
+            Polynomial,
+            [(1, 2, 3)],
+            from_monomials=True
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -11,6 +11,7 @@ from polynomial import (
     ZeroPolynomial,
     LinearBinomial,
     QuadraticTrinomial,
+    DegreeError
 )
 from polynomial.frozen import Freezable
 
@@ -868,6 +869,38 @@ class TestPolynomialsOperations(unittest.TestCase):
         self._assert_polynomials_are_the_same(e, a + b)
         # b + a requires a cast since b's degree does change.
         self._assert_polynomials_are_the_same(ep, b + a)
+
+    def test_setting_empty_terms_mutable_degree(self):
+        """Test setting empty terms."""
+        mutable = [
+            Polynomial(1, 2, 3),
+            Monomial(1, 2),
+        ]
+
+        for val in mutable:
+            val.terms = []
+            self._assert_polynomials_are_the_same(val.zero_instance(), val)
+
+    def test_setting_empty_terms_immutable_degree(self):
+        """Test setting empty terms."""
+        immutable = [
+            QuadraticTrinomial(1, 2, 3),
+            LinearBinomial(1, 2),
+        ]
+
+        for val in immutable:
+            self.assertRaises(DegreeError, val.__setattr__, "terms", [])
+
+        try:
+            a = Constant(0)
+            a.terms = []
+            a = Constant(5)
+            a.terms = []
+        except DegreeError:
+            self.assertFalse(True, "Should be able to set Constant(0).terms to []")
+
+        a = Constant(1)
+        a.terms = []
 
 
 if __name__ == '__main__':

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -848,7 +848,7 @@ class TestPolynomialsOperations(unittest.TestCase):
         self.assertRaises(AttributeError, b.__setitem__, 0, 1)
         self.assertRaises(AttributeError, b.__setattr__, "a", 1)
 
-    def test_trinomial_addition(self):
+    def test_trinomial_binomial_addition(self):
         """Test that QuadraticTrinomial behaves as expected."""
         a = QuadraticTrinomial(1, 2, 3)
         b = LinearBinomial(1, 2)
@@ -859,7 +859,7 @@ class TestPolynomialsOperations(unittest.TestCase):
         # b + a requires a cast since b's degree does change.
         self._assert_polynomials_are_the_same(ep, b + a)
 
-    def test_constant_addition(self):
+    def test_binomial_constant_addition(self):
         """Test that Constant behaves as expected."""
         a = LinearBinomial(1, 2)
         b = Constant(3)
@@ -921,6 +921,113 @@ class TestPolynomialsOperations(unittest.TestCase):
 
         a = LinearBinomial(5 + 10j, 2 + 1j)
         self.assertEqual(a.root, -(2 + 1j)/(5 + 10j))
+
+    def test_pos(self):
+        """Test that a Polynomial is equal to its positive version."""
+        a = Polynomial(1, 2, 3)
+        b = Monomial(1, 2)
+        c = Constant(5)
+        d = ZeroPolynomial()
+        e = QuadraticTrinomial(1, 3, 7)
+        f = LinearBinomial(9, 2)
+
+        self._assert_polynomials_are_the_same(a, +a)
+        self._assert_polynomials_are_the_same(b, +b)
+        self._assert_polynomials_are_the_same(c, +c)
+        self._assert_polynomials_are_the_same(d, +d)
+        self._assert_polynomials_are_the_same(e, +e)
+        self._assert_polynomials_are_the_same(f, +f)
+
+    def test_div_by_zero(self):
+        """Test that division by 0 is not possible."""
+        to_test = [
+            Polynomial(1, 2, 3),
+            Monomial(1, 2),
+            Constant(5),
+            ZeroPolynomial(),
+            QuadraticTrinomial(1, 3, 7),
+            LinearBinomial(9, 2),
+        ]
+
+        for val in to_test:
+            self.assertRaises(ZeroDivisionError, val.__floordiv__, 0)
+            self.assertRaises(ZeroDivisionError, val.__ifloordiv__, 0)
+            self.assertRaises(ZeroDivisionError, val.__mod__, 0)
+            self.assertRaises(ZeroDivisionError, val.__imod__, 0)
+            self.assertRaises(ZeroDivisionError, val.__divmod__, 0)
+
+    def test_pow_by_negative(self):
+        """Test that pow by negative is not possible."""
+        to_test = [
+            Polynomial(1, 2, 3),
+            Monomial(1, 2),
+            Constant(5),
+            ZeroPolynomial(),
+            QuadraticTrinomial(1, 3, 7),
+            LinearBinomial(9, 2),
+        ]
+
+        for val in to_test:
+            self.assertRaises(ValueError, val.__pow__, -1)
+            self.assertRaises(ValueError, val.__ipow__, -2)
+
+    def test_pow_by_non_integer(self):
+        """Test that pow by negative is not possible."""
+        to_test = [
+            Polynomial(1, 2, 3),
+            Monomial(1, 2),
+            Constant(5),
+            ZeroPolynomial(),
+            QuadraticTrinomial(1, 3, 7),
+            LinearBinomial(9, 2),
+        ]
+
+        for val in to_test:
+            self.assertRaises(ValueError, val.__pow__, 1.2)
+            self.assertRaises(ValueError, val.__ipow__, 1.5)
+
+    def test_monomial_coefficient(self):
+        """Test that setting a Monomial's coefficient behaves as expected."""
+        a = Monomial(1, 2)
+        a.coefficient = 2
+        expected = Monomial(2, 2)
+        self._assert_polynomials_are_the_same(expected, a)
+        b = Monomial(1, 2)
+        b.coefficient = 0
+        expected = Monomial(0, 0)
+        self._assert_polynomials_are_the_same(expected, b)
+
+    def test_constant_equality(self):
+        """Test that pow by negative is not possible."""
+        to_test = [
+            Polynomial(1),
+            Monomial(1, 0),
+            Constant(1),
+        ]
+
+        for val in to_test:
+            self.assertEqual(Constant(1), val)
+
+    def test_inequality(self):
+        """Test that pow by negative is not possible."""
+        to_test = [
+            Polynomial(1, 2, 3),
+            Monomial(1, 2),
+            Constant(5),
+            ZeroPolynomial(),
+            QuadraticTrinomial(1, 3, 7),
+            LinearBinomial(9, 2),
+            7
+        ]
+
+        for i, lhs in enumerate(to_test):
+            for j, rhs in enumerate(to_test):
+                if i == j:
+                    self.assertTrue(lhs == lhs)
+                    self.assertFalse(lhs != lhs)
+                else:
+                    self.assertFalse(lhs == rhs)
+                    self.assertNotEqual(lhs, rhs)
 
 
 if __name__ == '__main__':

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -571,17 +571,61 @@ class TestPolynomialsOperations(unittest.TestCase):
         m1 = Monomial(1, 5) << 10
         m2 = Monomial(1, 15) << -10
         m3 = Constant(5) << 10
+        m4 = Monomial(1, 15)
+        m4 <<= -10
 
         self._assert_polynomials_are_the_same(Monomial(1, 15), m1)
         self._assert_polynomials_are_the_same(Monomial(1, 5), m2)
         self._assert_polynomials_are_the_same(Monomial(5, 10), m3)
+        self._assert_polynomials_are_the_same(Monomial(1, 5), m2)
 
     def test_rshift_monomial(self):
         """Test that rshift on a monomial behaves correctly."""
         m1 = Monomial(1, 5) >> -10
         m2 = Monomial(1, 15) >> 10
+        m3 = Monomial(1, 5)
+        m3 >>= -10
+
         self._assert_polynomials_are_the_same(Monomial(1, 15), m1)
         self._assert_polynomials_are_the_same(Monomial(1, 5), m2)
+        self._assert_polynomials_are_the_same(Monomial(1, 15), m3)
+
+    def test_lshift_zero_monomial(self):
+        """Test that lshift on a zero monomial behaves correctly."""
+        m = Monomial(0, 1) << 5
+        c = Constant(0) << 10
+        z = ZeroPolynomial() << 2
+        em = Monomial(0, 0)
+        ec = Constant(0)
+        ez = ZeroPolynomial()
+
+        self._assert_polynomials_are_the_same(em, m)
+        self._assert_polynomials_are_the_same(ec, c)
+        self._assert_polynomials_are_the_same(ez, z)
+
+    def test_shift_zero_polynomial(self):
+        """Test that shifting zero polynomial does nothing."""
+        z = ZeroPolynomial()
+        z1 = z << 1
+        z2 = z >> 1
+        z3 = z << -1
+        z4 = z >> -1
+        z5 = ZeroPolynomial()
+        z6 = ZeroPolynomial()
+        z7 = ZeroPolynomial()
+        z8 = ZeroPolynomial()
+        z5 <<= 1
+        z6 >>= 1
+        z7 <<= -1
+        z8 >>= -1
+        self._assert_polynomials_are_the_same(z, z1)
+        self._assert_polynomials_are_the_same(z, z2)
+        self._assert_polynomials_are_the_same(z, z3)
+        self._assert_polynomials_are_the_same(z, z4)
+        self._assert_polynomials_are_the_same(z, z5)
+        self._assert_polynomials_are_the_same(z, z6)
+        self._assert_polynomials_are_the_same(z, z7)
+        self._assert_polynomials_are_the_same(z, z8)
 
     def test_shift_polynomial_past_end(self):
         """Test that shifting a polynomial beyond 0 yields 0."""
@@ -601,16 +645,12 @@ class TestPolynomialsOperations(unittest.TestCase):
         self._assert_polynomials_are_the_same(m0, m2)
 
     def test_shifting_constant_not_inplace(self):
-        """Test that constant/zero objects are not modified in place."""
+        """Test that constant objects are not modified in place."""
         c = Constant(5)
         c1 = c
         c1 <<= 5
-        z = ZeroPolynomial()
-        z1 = z
-        z1 <<= 5
 
         self.assertIsNot(c, c1)
-        self.assertIsNot(z, z1)
 
     def test_constant_constant_mul_yields_constant(self):
         """Test that Constant * Constant yields Constant."""
@@ -1051,6 +1091,30 @@ class TestPolynomialsOperations(unittest.TestCase):
             copy_val = deepcopy(val)
             copy_val **= 5
             self._assert_polynomials_are_the_same(val ** 5, copy_val)
+
+    def test_ipow_zero_gives_one(self):
+        to_test = [
+            Polynomial(1, 2, 3),
+            Monomial(1, 2),
+            Constant(5),
+            ZeroPolynomial(),
+            QuadraticTrinomial(1, 3, 7),
+            LinearBinomial(9, 2),
+        ]
+
+        one_maps = {
+            Polynomial: Polynomial(1),
+            Monomial: Monomial(1, 0),
+            Constant: Constant(1),
+            ZeroPolynomial: Constant(1),
+            QuadraticTrinomial: Polynomial(1),
+            LinearBinomial: Polynomial(1),
+        }
+
+        for val in to_test:
+            expected = one_maps[type(val)]
+            val **= 0
+            self._assert_polynomials_are_the_same(expected, val)
 
 
 if __name__ == '__main__':

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -1,6 +1,7 @@
 """Unit-testing module for testing various polynomial operations."""
 
 import unittest
+from copy import deepcopy
 from math import inf
 
 from polynomial import (
@@ -399,6 +400,15 @@ class TestPolynomialsOperations(unittest.TestCase):
         # Test that sets and polynomials are correctly handled.
         self.assertIn(set(terms), p)
         self.assertIn(Polynomial(terms, from_monomials=True), p)
+
+    def test_membership_against_invalid_types(self):
+        """Test that all valid types are handled in membership check."""
+        x = Polynomial("a", 2, 3)
+        self.assertRaises(ValueError, x.__contains__, 5)
+        self.assertRaises(ValueError, x.__contains__, "5")
+        self.assertRaises(ValueError, x.__contains__, "a")
+        self.assertRaises(ValueError, x.__contains__, 1.2)
+        self.assertRaises(ValueError, x.__contains__, 1+0j)
 
     def test_membership_false_on_partial_match(self):
         """Tests that membership is only true if all elements match."""
@@ -1009,7 +1019,7 @@ class TestPolynomialsOperations(unittest.TestCase):
             self.assertEqual(Constant(1), val)
 
     def test_inequality(self):
-        """Test that pow by negative is not possible."""
+        """Test that distinct values do not equal other."""
         to_test = [
             Polynomial(1, 2, 3),
             Monomial(1, 2),
@@ -1028,6 +1038,19 @@ class TestPolynomialsOperations(unittest.TestCase):
                 else:
                     self.assertFalse(lhs == rhs)
                     self.assertNotEqual(lhs, rhs)
+
+    def test_ipow_matches_pow(self):
+        to_test = [
+            Polynomial(1, 2, 3),
+            Monomial(1, 2),
+            Constant(5),
+            ZeroPolynomial(),
+        ]
+
+        for val in to_test:
+            copy_val = deepcopy(val)
+            copy_val **= 5
+            self._assert_polynomials_are_the_same(val ** 5, copy_val)
 
 
 if __name__ == '__main__':

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -848,12 +848,14 @@ class TestPolynomialsOperations(unittest.TestCase):
         self.assertRaises(AttributeError, b.__setattr__, "a", 1)
 
     def test_trinomial_addition(self):
-        """Test that QuadraticTrinomial does not change except on degree change."""
+        """Test that QuadraticTrinomial behaves as expected."""
         a = QuadraticTrinomial(1, 2, 3)
         b = LinearBinomial(1, 2)
         e = QuadraticTrinomial(1, 3, 5)
         ep = Polynomial(e)
+        # a + b is safe because a's degree does not change.
         self._assert_polynomials_are_the_same(e, a + b)
+        # b + a requires a cast since b's degree does change.
         self._assert_polynomials_are_the_same(ep, b + a)
 
 

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -580,7 +580,7 @@ class TestPolynomialsOperations(unittest.TestCase):
         self._assert_polynomials_are_the_same(Monomial(1, 15), m1)
         self._assert_polynomials_are_the_same(Monomial(1, 5), m2)
         self._assert_polynomials_are_the_same(Monomial(5, 10), m3)
-        self._assert_polynomials_are_the_same(Monomial(1, 5), m2)
+        self._assert_polynomials_are_the_same(Monomial(1, 5), m4)
 
     def test_rshift_monomial(self):
         """Test that rshift on a monomial behaves correctly."""
@@ -1028,7 +1028,7 @@ class TestPolynomialsOperations(unittest.TestCase):
             self.assertRaises(ValueError, val.__ipow__, -2)
 
     def test_pow_by_non_integer(self):
-        """Test that pow by negative is not possible."""
+        """Test that pow by non-integer type is not possible."""
         to_test = [
             Polynomial(1, 2, 3),
             Monomial(1, 2),
@@ -1054,11 +1054,12 @@ class TestPolynomialsOperations(unittest.TestCase):
         self._assert_polynomials_are_the_same(expected, b)
 
     def test_constant_equality(self):
-        """Test that pow by negative is not possible."""
+        """Test that Constant(1) is equal to other instances of 1."""
         to_test = [
             Polynomial(1),
             Monomial(1, 0),
             Constant(1),
+            1
         ]
 
         for val in to_test:

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -947,7 +947,10 @@ class TestPolynomialsOperations(unittest.TestCase):
             a = Constant(5)
             a.terms = []
         except DegreeError:
-            self.assertFalse(True, "Should be able to set Constant(0).terms to []")
+            self.assertFalse(
+                True,
+                "Should be able to set Constant(0).terms to []"
+            )
 
         a = Constant(1)
         a.terms = []

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -14,7 +14,7 @@ from polynomial import (
     QuadraticTrinomial,
     DegreeError
 )
-from polynomial.core import extract_polynomial
+from polynomial.core import extract_polynomial, FixedDegreePolynomial
 from polynomial.frozen import Freezable
 
 
@@ -1218,7 +1218,7 @@ class TestPolynomialsOperations(unittest.TestCase):
             x = LinearBinomial(1, 2)
             self.assertRaises(DegreeError, x.__setattr__, attr, val)
 
-    def test_setitem_raises_error(self):
+    def test_setitem_is_ok(self):
         """Test that setitem is fine for valid inputs."""
         x = Constant(5)
         x.a = 1

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -443,8 +443,8 @@ class TestPolynomialsOperations(unittest.TestCase):
         """Test that the ZeroPolynomial raises errors when setting values."""
         z = ZeroPolynomial()
 
-        self.assertRaises(AttributeError, z.__setattr__, "x", 5)
-        self.assertRaises(AttributeError, z.__setitem__, 0, 5)
+        self.assertRaises(DegreeError, z.__setattr__, "x", 5)
+        self.assertRaises(DegreeError, z.__setitem__, 0, 5)
 
     def test_frozen_polynomial_raises_err(self):
         f = FrozenPolynomial(1, 2, 3)
@@ -1206,6 +1206,36 @@ class TestPolynomialsOperations(unittest.TestCase):
         self.assertEqual(0, Constant(0).calculate(5))
         self.assertEqual(0, Monomial(0, 1).calculate(1.1))
 
+    def test_setattr_raises_error(self):
+        """Test that setting invalid terms raises an error."""
+        invalid_setattrs = [
+            ("_vector", [0, 0, 1]),
+            ("terms", [(1, 2), (0, 1)]),
+            ("terms", [(0, 2), (0, 1)]),
+            ("terms", [(0, 1), (1, 0)]),
+        ]
+        for attr, val in invalid_setattrs:
+            x = LinearBinomial(1, 2)
+            self.assertRaises(DegreeError, x.__setattr__, attr, val)
+
+    def test_setitem_raises_error(self):
+        """Test that setitem is fine for valid inputs."""
+        x = Constant(5)
+        x.a = 1
+        self._assert_polynomials_are_the_same(Constant(1), x)
+        x[0] = 0
+        self._assert_polynomials_are_the_same(Constant(0), x)
+
+    def test_setitem_raises_error(self):
+        """Test that setitem raises error on invalid inputs."""
+        lb = LinearBinomial(5, 1)
+        qt = QuadraticTrinomial(1, 2, 3)
+        self.assertRaises(DegreeError, lb.__setattr__, "a", 0)
+        self.assertRaises(DegreeError, qt.__setattr__, "a", 0)
+        lb = LinearBinomial(5, 1)
+        qt = QuadraticTrinomial(1, 2, 3)
+        self.assertRaises(DegreeError, lb.__setitem__, 1, 0)
+        self.assertRaises(DegreeError, qt.__setitem__, 2, 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -858,6 +858,17 @@ class TestPolynomialsOperations(unittest.TestCase):
         # b + a requires a cast since b's degree does change.
         self._assert_polynomials_are_the_same(ep, b + a)
 
+    def test_constant_addition(self):
+        """Test that Constant behaves as expected."""
+        a = LinearBinomial(1, 2)
+        b = Constant(3)
+        e = LinearBinomial(1, 5)
+        ep = Polynomial(e)
+        # a + b is safe because a's degree does not change.
+        self._assert_polynomials_are_the_same(e, a + b)
+        # b + a requires a cast since b's degree does change.
+        self._assert_polynomials_are_the_same(ep, b + a)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -847,6 +847,15 @@ class TestPolynomialsOperations(unittest.TestCase):
         self.assertRaises(AttributeError, b.__setitem__, 0, 1)
         self.assertRaises(AttributeError, b.__setattr__, "a", 1)
 
+    def test_trinomial_addition(self):
+        """Test that QuadraticTrinomial does not change except on degree change."""
+        a = QuadraticTrinomial(1, 2, 3)
+        b = LinearBinomial(1, 2)
+        e = QuadraticTrinomial(1, 3, 5)
+        ep = Polynomial(e)
+        self._assert_polynomials_are_the_same(e, a + b)
+        self._assert_polynomials_are_the_same(ep, b + a)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -443,8 +443,8 @@ class TestPolynomialsOperations(unittest.TestCase):
         """Test that the ZeroPolynomial raises errors when setting values."""
         z = ZeroPolynomial()
 
-        self.assertRaises(DegreeError, z.__setattr__, "x", 5)
-        self.assertRaises(DegreeError, z.__setitem__, 0, 5)
+        self.assertRaises(AttributeError, z.__setattr__, "x", 5)
+        self.assertRaises(AttributeError, z.__setitem__, 0, 5)
 
     def test_frozen_polynomial_raises_err(self):
         f = FrozenPolynomial(1, 2, 3)

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -902,6 +902,26 @@ class TestPolynomialsOperations(unittest.TestCase):
         a = Constant(1)
         a.terms = []
 
+    def test_linear_binomial_roots(self):
+        """Test that LinearBinomial.root is correct."""
+        a = LinearBinomial(10, 0)
+        self.assertEqual(a.root, 0)
+
+        a = LinearBinomial(-10, 0)
+        self.assertEqual(a.root, 0)
+
+        a = LinearBinomial(11, 5)
+        self.assertEqual(a.root, -5/11)
+
+        a = LinearBinomial(12.1, 3)
+        self.assertEqual(a.root, -3/12.1)
+
+        a = LinearBinomial(13.2, 3.6)
+        self.assertEqual(a.root, -3.6/13.2)
+
+        a = LinearBinomial(5 + 10j, 2 + 1j)
+        self.assertEqual(a.root, -(2 + 1j)/(5 + 10j))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_repr.py
+++ b/tests/test_polynomials_repr.py
@@ -1,6 +1,9 @@
 """Unit-testing module defining polynomials __repr__ test cases."""
 
+import inspect
 import unittest
+
+import polynomial
 from polynomial import (
     Constant,
     LinearBinomial,
@@ -8,7 +11,9 @@ from polynomial import (
     Polynomial,
     QuadraticTrinomial,
     ZeroPolynomial,
-    FrozenPolynomial
+    FrozenPolynomial,
+    Trinomial,
+    Binomial
 )
 
 
@@ -55,11 +60,27 @@ class TestPolynomialsRepr(unittest.TestCase):
 
         self.assertEqual(expect, r)
 
+    def test_binomial(self):
+        """Test that repr() output of a Binomial is valid."""
+        expect = "Binomial(Monomial(4, 3), Monomial(2, 1))"
+
+        r = repr(Binomial((4, 3), (2, 1)))
+
+        self.assertEqual(expect, r)
+
     def test_linear_binomial(self):
         """Test that repr() output of a LinearBinomial is valid."""
         expect = "LinearBinomial(5, 2)"
 
         r = repr(LinearBinomial(5, 2))
+
+        self.assertEqual(expect, r)
+
+    def test_trinomial(self):
+        """Test that repr() output of a Trinomial is valid."""
+        expect = "Trinomial(Monomial(5, 5), Monomial(2, 3), Monomial(1, 1))"
+
+        r = repr(Trinomial((5, 5), (2, 3), (1, 1)))
 
         self.assertEqual(expect, r)
 
@@ -79,10 +100,7 @@ class TestPolynomialsRepr(unittest.TestCase):
         self.assertEqual(expect, r)
 
     def test_all_reprs_start_correctly(self):
-        """Automatically tests that the repr of a class starts correctly."""
-        import inspect
-        import polynomial
-        print(dir(polynomial))
+        """Test that the repr of all classes start correctly."""
         for cls_str in dir(polynomial):
             cls = getattr(polynomial, cls_str)
             if not inspect.isclass(cls):

--- a/tests/test_polynomials_repr.py
+++ b/tests/test_polynomials_repr.py
@@ -78,6 +78,22 @@ class TestPolynomialsRepr(unittest.TestCase):
         r = repr(FrozenPolynomial(1, 2, 3))
         self.assertEqual(expect, r)
 
+    def test_all_reprs_start_correctly(self):
+        """Automatically tests that the repr of a class starts correctly."""
+        import inspect
+        import polynomial
+        print(dir(polynomial))
+        for cls_str in dir(polynomial):
+            cls = getattr(polynomial, cls_str)
+            if not inspect.isclass(cls):
+                continue
+            if not issubclass(cls, Polynomial):
+                continue
+            self.assertTrue(
+                repr(cls()).startswith(cls_str),
+                "{0} should start with {1}".format(repr(cls()), cls_str)
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds an interface which ensures that the object's degree is valid (eg. not unchanged in the case of Constant, since that can be zero) - if the degree becomes invalid, it instantiates a new Polynomial and does the same operation on the new Polynomial instead.

This is implemented for LinearBinomial, QuadraticTrinomial and Constant (and by extension, ZeroPolynomial, although this doesn't really mean anything in combination with Freezable).

I also simplified the code to get rid of statements that never execute and to reduce the amount of code:

`Polynomial.__init__`: we should never get None for an iterable from the decorator (and if the user passes None, this isn't an input we should accept).

`Polynomial.monomials`: Since monomials is a property, there is no way to get the reverse order Monomials (can't specify reverse=True).

This also enables short circuiting for != checks (if the degree is not equal, then the terms don't need to be checked).

This simplifies Monomial by getting rid of redundant code, and utilizing the new mechanisms for enforcing degree constraints on Constants and Polynomials. It also makes these operations in place, as we utilize `FixedDegreePolynomial` to return a Polynomial copy when in place modification leads to an invalid state.

This also removes `__copy__`, `__deepcopy__` methods, as these have no effect on behaviour (semantics are the same, except copy also copies _vector), and are only really needed for more complicated types - the ones here just wrap a list.

This also includes the changes from #38 - I figured it would be better to just merge once since I already included the commits, so I closed the previous PR.

This also adds tests to reach 100% coverage (though some things were deleted).