### PR TITLE
Definite integral only

### DIFF
--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -245,7 +245,7 @@ class Polynomial:
     def indefinite_integral(self):
         """Return the polynomial object which is the integral of self."""
         if not self:
-            return Polynomial(0)
+            return Polynomial("C")
 
         return Polynomial(
             [c/x for c, x in

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -236,20 +236,18 @@ class Polynomial:
 
     def integral(self, a, b):
         """Return the integral of self from a to b."""
-        res = self.indefinite_integral
-        # Last term of indefinite integral is C.
-        res[0] = 0
+        res = self._indefinite_integral
         return res.calculate(b) - res.calculate(a)
 
     @property
-    def indefinite_integral(self):
+    def _indefinite_integral(self):
         """Return the polynomial object which is the integral of self."""
         if not self:
-            return Polynomial("C")
+            return Polynomial()
 
         return Polynomial(
             [c/x for c, x in
-                zip(self, range(self.degree + 1, 0, -1))] + ["C"]
+                zip(self, range(self.degree + 1, 0, -1))] + [0]
             )
 
     @property

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -234,6 +234,21 @@ class Polynomial:
              in zip(self, reversed(factors))]
         )
 
+    def integral(self, a, b):
+        """Return the integral of self from a to b."""
+        res = self.indefinite_integral
+        # Last term of indefinite integral is C.
+        res[0] = 0
+        return res.calculate(b) - res.calculate(a)
+
+    @property
+    def indefinite_integral(self):
+        """Return the polynomial object which is the integral of self."""
+        return Polynomial(
+            [c/x for c, x in
+                zip(self, range(self.degree + 1, 0, -1))] + ["C"]
+            )
+
     @property
     def terms(self):
         """Get the terms of self as a list of tuples in coeff, deg form.

--- a/polynomial/core.py
+++ b/polynomial/core.py
@@ -244,6 +244,9 @@ class Polynomial:
     @property
     def indefinite_integral(self):
         """Return the polynomial object which is the integral of self."""
+        if not self:
+            return Polynomial(0)
+
         return Polynomial(
             [c/x for c, x in
                 zip(self, range(self.degree + 1, 0, -1))] + ["C"]

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -1374,14 +1374,16 @@ class TestPolynomialsOperations(unittest.TestCase):
         self.assertEqual(_sub([], [(1, 2), (3, 1)]), [(-1, 2), (-3, 1)])
         self.assertEqual(_sub([(1, 2), (3, 1)], []), [(1, 2), (3, 1)])
 
-    def test_integral_constant(self):
-        """Test that integrating against a constant is correct."""
+    def test_integral_of_zero(self):
+        """Test that integral of a zero polynomial is zero."""
         p = Polynomial()
         z = ZeroPolynomial()
 
         self.assertEqual(0, z.integral(-1000, 1000))
         self.assertEqual(0, p.integral(-1000, 1000))
 
+    def test_integral_constant(self):
+        """Test that integrating against a constant is correct."""
         c = Constant(2)
         p = Polynomial(3)
         m = Monomial(1.2, 0)

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -1374,6 +1374,40 @@ class TestPolynomialsOperations(unittest.TestCase):
         self.assertEqual(_sub([], [(1, 2), (3, 1)]), [(-1, 2), (-3, 1)])
         self.assertEqual(_sub([(1, 2), (3, 1)], []), [(1, 2), (3, 1)])
 
+    def test_integral_zero(self):
+        """Test that the integral of the zero polynomial is 'C'."""
+        p = Polynomial()
+        z = ZeroPolynomial()
+        e = Polynomial("C")
+
+        self._assert_polynomials_are_the_same(e, z.indefinite_integral)
+        self._assert_polynomials_are_the_same(e, p.indefinite_integral)
+
+    def test_integral_constant(self):
+        """Test that integrating against a constant is correct."""
+        p = Polynomial()
+        z = ZeroPolynomial()
+
+        self.assertEqual(0, z.integral(-1000, 1000))
+        self.assertEqual(0, p.integral(-1000, 1000))
+
+        c = Constant(2)
+        p = Polynomial(3)
+        m = Monomial(1.2, 0)
+
+        self.assertEqual(20, c.integral(-5, 5))
+        self.assertEqual(45, p.integral(-10, 5))
+        self.assertAlmostEqual(48, m.integral(-50.5, -10.5))
+
+    def test_general_integral(self):
+        """Test that integration works as expected."""
+        p = Polynomial(3, 2, 1)
+        expected = Polynomial(1.0, 1.0, 1.0, "C")
+        result = p.indefinite_integral
+        self._assert_polynomials_are_the_same(expected, result)
+        self.assertAlmostEqual(3, p.integral(0, 1))
+        self.assertAlmostEqual(4, p.integral(-1, 1))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_polynomials_operations.py
+++ b/tests/test_polynomials_operations.py
@@ -1374,15 +1374,6 @@ class TestPolynomialsOperations(unittest.TestCase):
         self.assertEqual(_sub([], [(1, 2), (3, 1)]), [(-1, 2), (-3, 1)])
         self.assertEqual(_sub([(1, 2), (3, 1)], []), [(1, 2), (3, 1)])
 
-    def test_integral_zero(self):
-        """Test that the integral of the zero polynomial is 'C'."""
-        p = Polynomial()
-        z = ZeroPolynomial()
-        e = Polynomial("C")
-
-        self._assert_polynomials_are_the_same(e, z.indefinite_integral)
-        self._assert_polynomials_are_the_same(e, p.indefinite_integral)
-
     def test_integral_constant(self):
         """Test that integrating against a constant is correct."""
         p = Polynomial()
@@ -1402,9 +1393,6 @@ class TestPolynomialsOperations(unittest.TestCase):
     def test_general_integral(self):
         """Test that integration works as expected."""
         p = Polynomial(3, 2, 1)
-        expected = Polynomial(1.0, 1.0, 1.0, "C")
-        result = p.indefinite_integral
-        self._assert_polynomials_are_the_same(expected, result)
         self.assertAlmostEqual(3, p.integral(0, 1))
         self.assertAlmostEqual(4, p.integral(-1, 1))
 


### PR DESCRIPTION
Dear @allexks 

Thanks for this nice package. I wonder if you would consider merging this PR - it's a cut-down version of @philippeitis changes to add integration. Instead of dealing with the tricky problem of how to represent an indefinite integral, it simply implements only the definite integral. The indefinite integral is a private method used for the definite integral, avoiding the constant "C".

If this functionality could be added, it would help me out with some calculations involving Sterling numbers. And the indefinite integral could be added later.

Thanks.